### PR TITLE
5221 scrolling input fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mem": "^8.1.1",
     "path-browserify": "^0.0.0",
     "react": "17.0.1",
-    "react-native": "0.64.0",
+    "react-native": "0.65.1",
     "react-native-aes-crypto": "^1.3.10",
     "react-native-android-open-settings": "^1.3.0",
     "react-native-biometrics": "^2.1.4",

--- a/src/components/seed-phrase-word-input/seed-phrase-word-input.styles.ts
+++ b/src/components/seed-phrase-word-input/seed-phrase-word-input.styles.ts
@@ -9,7 +9,10 @@ export const useSeedPhraseWordInputStyles = createUseStylesConfig(({ colors, typ
     width: formatSize(108),
     minHeight: formatSize(48),
     height: formatSize(48),
-    paddingRight: formatSize(12),
+    paddingRight: formatSize(4),
+    paddingTop: formatSize(12),
+    paddingBottom: formatSize(12),
+    paddingLeft: formatSize(2),
     textAlign: 'center',
     ...typography.body15Semibold
   },

--- a/src/components/seed-phrase-word-input/seed-phrase-word-input.styles.ts
+++ b/src/components/seed-phrase-word-input/seed-phrase-word-input.styles.ts
@@ -10,10 +10,9 @@ export const useSeedPhraseWordInputStyles = createUseStylesConfig(({ colors, typ
     minHeight: formatSize(48),
     height: formatSize(48),
     paddingRight: formatSize(4),
-    paddingTop: formatSize(12),
-    paddingBottom: formatSize(12),
-    paddingLeft: formatSize(2),
-    textAlign: 'center',
+    paddingTop: formatSize(8),
+    paddingBottom: formatSize(8),
+    paddingLeft: formatSize(0),
     ...typography.body15Semibold
   },
   title: {

--- a/src/components/seed-phrase-word-input/seed-phrase-word-input.tsx
+++ b/src/components/seed-phrase-word-input/seed-phrase-word-input.tsx
@@ -29,6 +29,7 @@ export const SeedPhraseWordInput: FC<SeedPhraseWordInputProps> = ({ inputName, p
         onBlur={() => helpers.setTouched(true)}
         onChangeText={field.onChange(inputName)}
         style={styles.wordInput}
+        textAlign="center"
       />
     </View>
   );


### PR DESCRIPTION
was trying to fix not only scrolling inside input, but also a tilt of input caret to the right. I found an issue in react-native package that was fixed in new version - https://github.com/facebook/react-native/issues/27658 but issue still occurs. Decided to leave updated version of react native because of being on the beginning of the sprint, so we just can do more tests to look for breaking changes. Tests are passing.

the problem of input was fixed size and unable to box placeholder because of internal padding. Was talking with designer, he said, that we can manage padding for good visual feedback on components.