### PR TITLE
A-005: bumped security for android

### DIFF
--- a/src/utils/keychain.utils.ts
+++ b/src/utils/keychain.utils.ts
@@ -9,8 +9,7 @@ export const PASSWORD_STORAGE_KEY = 'biometry-protected-app-password';
 
 export const getKeychainOptions = (key: string): Keychain.Options => ({
   service: `${APP_IDENTIFIER}/${key}`,
-  securityLevel: isAndroid ? Keychain.SECURITY_LEVEL.SECURE_HARDWARE : undefined,
-  storage: isAndroid ? Keychain.STORAGE_TYPE.RSA : undefined
+  securityLevel: isAndroid ? Keychain.SECURITY_LEVEL.SECURE_HARDWARE : undefined
 });
 
 export const biometryKeychainOptions: Keychain.Options = {

--- a/src/utils/keychain.utils.ts
+++ b/src/utils/keychain.utils.ts
@@ -1,12 +1,16 @@
 import Keychain from 'react-native-keychain';
 
+import { isAndroid } from '../config/system';
+
 export const APP_IDENTIFIER = 'com.madfish.temple-wallet';
 
 export const PASSWORD_CHECK_KEY = 'app-password';
 export const PASSWORD_STORAGE_KEY = 'biometry-protected-app-password';
 
 export const getKeychainOptions = (key: string): Keychain.Options => ({
-  service: `${APP_IDENTIFIER}/${key}`
+  service: `${APP_IDENTIFIER}/${key}`,
+  securityLevel: isAndroid ? Keychain.SECURITY_LEVEL.SECURE_HARDWARE : undefined,
+  storage: isAndroid ? Keychain.STORAGE_TYPE.RSA : undefined
 });
 
 export const biometryKeychainOptions: Keychain.Options = {


### PR DESCRIPTION
https://www.notion.so/madfissolutions/A-005-React-native-keychain-library-storage-option-is-not-specified-credentials-are-stored-without-7c2b19d849cf4192972e5335af52e790

It was something like 
```ts
export const getKeychainOptions = (key: string): Keychain.Options => ({
  service: `${APP_IDENTIFIER}/${key}`,
  securityLevel: isAndroid ? Keychain.SECURITY_LEVEL.SECURE_HARDWARE : undefined
  storage: isAndroid ? Keychain.STORAGE_TYPE.RSA : undefined
});
```

but importing of seedphrase was not working. Removing `storage` property is way to fix this