### PR TITLE
Topup tabs clickable fix

### DIFF
--- a/src/screens/buy/debit.tsx
+++ b/src/screens/buy/debit.tsx
@@ -21,7 +21,7 @@ export const Debit = () => {
       <Divider size={formatSize(16)} />
       <WhiteContainer>
         <View style={styles.providerLogo}>
-          <Icon name={IconNameEnum.MoonPay} size={formatSize(160)} color={colors.black} />
+          <Icon name={IconNameEnum.MoonPay} width={formatSize(160)} height={formatSize(40)} color={colors.black} />
         </View>
         <View style={styles.divider} />
         <TouchableOpacity style={styles.textContainer} onPress={() => openUrl(url)} disabled={!url}>


### PR DESCRIPTION
https://www.notion.so/madfissolutions/Right-part-of-Crypto-tab-in-Top-up-TEZ-balance-is-not-clickable-1d9b7a535199452c9b46dbef20e02a3b