### PR TITLE
Currency selector fixes

### DIFF
--- a/src/components/asset-amount-input/asset-amount-input.tsx
+++ b/src/components/asset-amount-input/asset-amount-input.tsx
@@ -82,6 +82,7 @@ const AssetAmountInputComponent: FC<AssetAmountInputProps> = ({
   const isLiquidityProviderToken = isDefined(frozenBalance);
 
   const { hasExchangeRate, exchangeRate, getExchangeRate } = useExchangeRate(value.asset);
+  const validExchangeRate = useMemo(() => exchangeRate ?? 1, [exchangeRate]);
 
   const inputValueRef = useRef<BigNumber>();
 
@@ -92,14 +93,18 @@ const AssetAmountInputComponent: FC<AssetAmountInputProps> = ({
           return mutezToTz(value.amount, value.asset.decimals);
         } else {
           if (isDefined(inputValueRef.current)) {
-            const currentTokenValue = dollarToTokenAmount(inputValueRef.current, value.asset.decimals, exchangeRate);
+            const currentTokenValue = dollarToTokenAmount(
+              inputValueRef.current,
+              value.asset.decimals,
+              validExchangeRate
+            );
 
             if (currentTokenValue.isEqualTo(value.amount) || isCollectible(value.asset)) {
               return inputValueRef.current;
             }
           }
 
-          return tokenToDollarAmount(value.amount, value.asset.decimals, exchangeRate);
+          return tokenToDollarAmount(value.amount, value.asset.decimals, validExchangeRate);
         }
       }
 
@@ -109,7 +114,7 @@ const AssetAmountInputComponent: FC<AssetAmountInputProps> = ({
     inputValueRef.current = newNumericInputValue;
 
     return newNumericInputValue;
-  }, [value.amount, isTokenInputType, value.asset.decimals, exchangeRate]);
+  }, [value.amount, isTokenInputType, value.asset.decimals, validExchangeRate]);
 
   const onChange = useCallback(
     newInputValue => {
@@ -117,7 +122,7 @@ const AssetAmountInputComponent: FC<AssetAmountInputProps> = ({
 
       onValueChange({
         ...value,
-        amount: getDefinedAmount(newInputValue, value.asset.decimals, exchangeRate, isTokenInputType)
+        amount: getDefinedAmount(newInputValue, value.asset.decimals, validExchangeRate, isTokenInputType)
       });
     },
     [value, onValueChange, isTokenInputType]
@@ -142,7 +147,7 @@ const AssetAmountInputComponent: FC<AssetAmountInputProps> = ({
       amount: getDefinedAmount(
         inputValueRef.current,
         value.asset.decimals,
-        exchangeRate,
+        validExchangeRate,
         tokenTypeIndex === TOKEN_INPUT_TYPE_INDEX
       )
     });
@@ -155,7 +160,7 @@ const AssetAmountInputComponent: FC<AssetAmountInputProps> = ({
       const newExchangeRate = getExchangeRate(asset);
 
       onValueChange({
-        amount: getDefinedAmount(inputValueRef.current, decimals, newExchangeRate, isTokenInputType),
+        amount: getDefinedAmount(inputValueRef.current, decimals, newExchangeRate ?? 1, isTokenInputType),
         asset
       });
     },

--- a/src/components/styled-radio-buttons-group/styled-radio-buttons-group.styles.ts
+++ b/src/components/styled-radio-buttons-group/styled-radio-buttons-group.styles.ts
@@ -10,7 +10,7 @@ export const useStyledRadioButtonsGroupStyles = createUseStyles(({ colors, typog
     flexDirection: 'row-reverse',
     justifyContent: 'space-around',
     width: '100%',
-    paddingVertical: formatSize(6)
+    height: formatSize(44)
   },
   label: {
     ...typography.body15Semibold,

--- a/src/components/styled-radio-buttons-group/styled-radio-buttons-group.tsx
+++ b/src/components/styled-radio-buttons-group/styled-radio-buttons-group.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { View } from 'react-native';
+import { View, ViewStyle } from 'react-native';
 import { RadioButtonProps, RadioGroup } from 'react-native-radio-buttons-group';
 
 import { EventFn } from '../../config/general';
@@ -19,9 +19,10 @@ export interface RadioButtonsGroupProps<T extends string> {
 interface Props<T extends string> extends RadioButtonsGroupProps<T> {
   value: T;
   onChange: EventFn<T>;
+  labelStyle?: ViewStyle;
 }
 
-export const StyledRadioButtonsGroup = <T extends string>({ value, buttons, onChange }: Props<T>) => {
+export const StyledRadioButtonsGroup = <T extends string>({ value, buttons, onChange, labelStyle }: Props<T>) => {
   const colors = useColors();
   const styles = useStyledRadioButtonsGroupStyles();
 
@@ -30,7 +31,7 @@ export const StyledRadioButtonsGroup = <T extends string>({ value, buttons, onCh
       buttons.map(radioButton => ({
         ...radioButton,
         id: radioButton.value,
-        labelStyle: styles.label,
+        labelStyle: [styles.label, labelStyle],
         containerStyle: styles.itemContainer,
         color: colors.orange,
         selected: radioButton.value === value

--- a/src/screens/fiat-settings/fiat-settings.styles.ts
+++ b/src/screens/fiat-settings/fiat-settings.styles.ts
@@ -1,0 +1,9 @@
+import { createUseStyles } from '../../styles/create-use-styles';
+
+export const useFiatSettingsStyles = createUseStyles(({ colors, typography }) => ({
+  label: {
+    ...typography.body15Regular,
+    color: colors.black,
+    flex: 1
+  }
+}));

--- a/src/screens/fiat-settings/fiat-settings.tsx
+++ b/src/screens/fiat-settings/fiat-settings.tsx
@@ -19,7 +19,7 @@ export const FiatSettings = () => {
   const radioButtons = useMemo(
     () =>
       FIAT_CURRENCIES.map(currency => ({
-        label: `${currency.symbol} ${currency.name} (${currency.fullname})`,
+        label: `${currency.symbol}  ${currency.name} (${currency.fullname})`,
         value: currency.name
       })),
     []

--- a/src/screens/fiat-settings/fiat-settings.tsx
+++ b/src/screens/fiat-settings/fiat-settings.tsx
@@ -9,13 +9,19 @@ import { setFiatCurrency } from '../../store/settings/settings-actions';
 import { useFiatCurrencySelector } from '../../store/settings/settings-selectors';
 import { usePageAnalytic } from '../../utils/analytics/use-analytics.hook';
 import { FiatCurrenciesEnum, FIAT_CURRENCIES } from '../../utils/exchange-rate.util';
+import { useFiatSettingsStyles } from './fiat-settings.styles';
 
 export const FiatSettings = () => {
   const dispatch = useDispatch();
   const selectedFiatCurrency = useFiatCurrencySelector();
+  const styles = useFiatSettingsStyles();
 
   const radioButtons = useMemo(
-    () => FIAT_CURRENCIES.map(currency => ({ label: currency.name, value: currency.name })),
+    () =>
+      FIAT_CURRENCIES.map(currency => ({
+        label: `${currency.symbol} ${currency.name} (${currency.fullname})`,
+        value: currency.name
+      })),
     []
   );
 
@@ -24,7 +30,12 @@ export const FiatSettings = () => {
 
   return (
     <ScreenContainer>
-      <StyledRadioButtonsGroup value={selectedFiatCurrency} buttons={radioButtons} onChange={handleChange} />
+      <StyledRadioButtonsGroup
+        labelStyle={styles.label}
+        value={selectedFiatCurrency}
+        buttons={radioButtons}
+        onChange={handleChange}
+      />
       <Divider />
     </ScreenContainer>
   );

--- a/src/screens/settings/settings.tsx
+++ b/src/screens/settings/settings.tsx
@@ -69,7 +69,7 @@ export const Settings = () => {
 
           <WhiteContainer>
             <WhiteContainerAction onPress={() => navigate(ScreensEnum.FiatSettings)}>
-              <WhiteContainerText text="Default Currencies" />
+              <WhiteContainerText text="Default Currency" />
               <View style={styles.shevronContainer}>
                 <Text style={styles.shevronText}>{fiatCurrency}</Text>
                 <Icon name={IconNameEnum.ChevronRight} size={formatSize(24)} />

--- a/src/store/currency/currency-selectors.ts
+++ b/src/store/currency/currency-selectors.ts
@@ -17,8 +17,8 @@ export const useFiatToTezosRates = () =>
 export const useExchangeRate = <T extends { address?: string; id?: number }>(asset: T) => {
   const exchangeRates = useUsdToTokenRates();
   const quotes = useFiatToTezosRates();
-  const exchangeRate: number = exchangeRates[getTokenSlug(asset)] ?? 1;
-  const exchangeRateTezos: number = exchangeRates[TEZ_TOKEN_SLUG] ?? 1;
+  const exchangeRate: number | undefined = exchangeRates[getTokenSlug(asset)];
+  const exchangeRateTezos: number | undefined = exchangeRates[TEZ_TOKEN_SLUG];
 
   const fiatCurrency = useFiatCurrencySelector();
 
@@ -28,7 +28,10 @@ export const useExchangeRate = <T extends { address?: string; id?: number }>(ass
   const hasExchangeRate = isDefined(exchangeRate);
 
   const getExchangeRate = useCallback(
-    (newAsset: TokenInterface): number => {
+    (newAsset: TokenInterface): number | undefined => {
+      if (!exchangeRate) {
+        return;
+      }
       const newExchangeRate = exchangeRates[getTokenSlug(newAsset)];
       const newFiatToUsdRate = quotes[fiatCurrency.toLowerCase()] / exchangeRateTezos;
       const newTrueExchangeRate = newFiatToUsdRate * newExchangeRate;
@@ -41,6 +44,6 @@ export const useExchangeRate = <T extends { address?: string; id?: number }>(ass
   return {
     getExchangeRate,
     hasExchangeRate,
-    exchangeRate: trueExchangeRate
+    exchangeRate: isNaN(trueExchangeRate) ? undefined : trueExchangeRate
   };
 };


### PR DESCRIPTION
- no exchange rate for NFT's and tokens without rate
- Default currencies => Default currency naming in settings item
- Change radio list labels

https://www.notion.so/madfissolutions/Support-base-currencies-for-displaying-token-equivalent-60aa2fcd03d34b3aa175680c32ca60da