### PR TITLE
Add lazy loading to tokens list

### DIFF
--- a/src/modals/send-modal/send-modal.tsx
+++ b/src/modals/send-modal/send-modal.tsx
@@ -96,7 +96,6 @@ export const SendModal: FC = () => {
         console.log(e);
       }
       setIsLoading(false);
-      console.log(address);
       if (address !== null) {
         receiverPublicKeyHash = address;
       } else if (!isValidAddress(receiverPublicKeyHash)) {

--- a/src/navigator/main-stack.tsx
+++ b/src/navigator/main-stack.tsx
@@ -43,7 +43,7 @@ import { Wallet } from '../screens/wallet/wallet';
 import { Welcome } from '../screens/welcome/welcome';
 import { loadSelectedBakerActions } from '../store/baking/baking-actions';
 import { loadExchangeRates } from '../store/currency/currency-actions';
-import { loadTezosBalanceActions, loadTokenBalancesActions } from '../store/wallet/wallet-actions';
+import { loadTezosBalanceActions, loadTokensWithBalancesActions } from '../store/wallet/wallet-actions';
 import { useIsAuthorisedSelector, useSelectedAccountSelector } from '../store/wallet/wallet-selectors';
 import { TEZ_TOKEN_METADATA } from '../token/data/tokens-metadata';
 import { emptyTokenMetadata } from '../token/interfaces/token-metadata.interface';
@@ -68,7 +68,7 @@ export const MainStackScreen = () => {
 
   const initDataLoading = () => {
     dispatch(loadTezosBalanceActions.submit());
-    dispatch(loadTokenBalancesActions.submit());
+    dispatch(loadTokensWithBalancesActions.submit());
     dispatch(loadSelectedBakerActions.submit());
   };
   const initLongRefreshLoading = () => {

--- a/src/screens/token-screen/token-screen.tsx
+++ b/src/screens/token-screen/token-screen.tsx
@@ -12,7 +12,7 @@ import { TokenEquityValue } from '../../components/token-equity-value/token-equi
 import { TokenScreenContentContainer } from '../../components/token-screen-content-container/token-screen-content-container';
 import { useTokenActivity } from '../../hooks/use-token-activity.hook';
 import { ScreensEnum, ScreensParamList } from '../../navigator/enums/screens.enum';
-import { loadRenderTokenBalanceActions } from '../../store/wallet/wallet-actions';
+import { loadTokenBalanceActions } from '../../store/wallet/wallet-actions';
 import { useSelectedAccountSelector, useTokensListSelector } from '../../store/wallet/wallet-selectors';
 import { formatSize } from '../../styles/format-size';
 import { getTokenSlug } from '../../token/utils/token.utils';
@@ -30,7 +30,7 @@ export const TokenScreen = () => {
   );
 
   useEffect(() => {
-    dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
+    dispatch(loadTokenBalanceActions.submit(getTokenSlug(token)));
   }, [dispatch]);
 
   const selectedAccount = useSelectedAccountSelector();

--- a/src/screens/token-screen/token-screen.tsx
+++ b/src/screens/token-screen/token-screen.tsx
@@ -1,5 +1,6 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
 import React, { useMemo } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { ActivityGroupsList } from '../../components/activity-groups-list/activity-groups-list';
 import { HeaderCardActionButtons } from '../../components/header-card-action-buttons/header-card-action-buttons';
@@ -11,6 +12,7 @@ import { TokenEquityValue } from '../../components/token-equity-value/token-equi
 import { TokenScreenContentContainer } from '../../components/token-screen-content-container/token-screen-content-container';
 import { useTokenActivity } from '../../hooks/use-token-activity.hook';
 import { ScreensEnum, ScreensParamList } from '../../navigator/enums/screens.enum';
+import { loadRenderTokenBalanceActions } from '../../store/wallet/wallet-actions';
 import { useSelectedAccountSelector, useTokensListSelector } from '../../store/wallet/wallet-selectors';
 import { formatSize } from '../../styles/format-size';
 import { getTokenSlug } from '../../token/utils/token.utils';
@@ -19,12 +21,17 @@ import { TokenInfo } from './token-info/token-info';
 
 export const TokenScreen = () => {
   const { token: initialToken } = useRoute<RouteProp<ScreensParamList, ScreensEnum.TokenScreen>>().params;
+  const dispatch = useDispatch();
   const tokensList = useTokensListSelector();
   const token = useMemo(
     () =>
       tokensList.find(candidateToken => getTokenSlug(candidateToken) === getTokenSlug(initialToken)) ?? initialToken,
     [tokensList, initialToken]
   );
+
+  useMemo(() => {
+    dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
+  }, []);
 
   const selectedAccount = useSelectedAccountSelector();
   const { activities, handleUpdate } = useTokenActivity(initialToken.address, initialToken.id.toString());

--- a/src/screens/token-screen/token-screen.tsx
+++ b/src/screens/token-screen/token-screen.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { ActivityGroupsList } from '../../components/activity-groups-list/activity-groups-list';
@@ -29,9 +29,9 @@ export const TokenScreen = () => {
     [tokensList, initialToken]
   );
 
-  useMemo(() => {
+  useEffect(() => {
     dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
-  }, []);
+  }, [dispatch]);
 
   const selectedAccount = useSelectedAccountSelector();
   const { activities, handleUpdate } = useTokenActivity(initialToken.address, initialToken.id.toString());

--- a/src/screens/wallet/token-list/token-list-item/token-list-item.tsx
+++ b/src/screens/wallet/token-list/token-list-item/token-list-item.tsx
@@ -1,12 +1,15 @@
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { View } from 'react-native';
+import { useDispatch } from 'react-redux';
 
 import { AssetValueText } from '../../../../components/asset-value-text/asset-value-text';
 import { HideBalance } from '../../../../components/hide-balance/hide-balance';
 import { TokenContainer } from '../../../../components/token-container/token-container';
 import { TokenContainerProps } from '../../../../components/token-container/token-container.props';
 import { EmptyFn } from '../../../../config/general';
+import { loadRenderTokenBalanceActions } from '../../../../store/wallet/wallet-actions';
+import { getTokenSlug } from '../../../../token/utils/token.utils';
 import { useTokenListItemStyles } from './token-list-item.styles';
 
 interface Props extends TokenContainerProps {
@@ -15,6 +18,11 @@ interface Props extends TokenContainerProps {
 
 export const TokenListItem: FC<Props> = ({ token, apy, onPress }) => {
   const styles = useTokenListItemStyles();
+  const dispatch = useDispatch();
+
+  useMemo(() => {
+    dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
+  }, []);
 
   return (
     <TouchableOpacity onPress={onPress}>

--- a/src/screens/wallet/token-list/token-list-item/token-list-item.tsx
+++ b/src/screens/wallet/token-list/token-list-item/token-list-item.tsx
@@ -1,5 +1,5 @@
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
-import React, { FC, useEffect } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import { useDispatch } from 'react-redux';
 
@@ -8,28 +8,40 @@ import { HideBalance } from '../../../../components/hide-balance/hide-balance';
 import { TokenContainer } from '../../../../components/token-container/token-container';
 import { TokenContainerProps } from '../../../../components/token-container/token-container.props';
 import { EmptyFn } from '../../../../config/general';
-import { loadRenderTokenBalanceActions } from '../../../../store/wallet/wallet-actions';
+import { ScreensEnum } from '../../../../navigator/enums/screens.enum';
+import { useNavigation } from '../../../../navigator/hooks/use-navigation.hook';
+import { loadTokenBalanceActions } from '../../../../store/wallet/wallet-actions';
 import { TEZ_TOKEN_SLUG } from '../../../../token/data/tokens-metadata';
 import { getTokenSlug } from '../../../../token/utils/token.utils';
 import { useTokenListItemStyles } from './token-list-item.styles';
 
 interface Props extends TokenContainerProps {
-  onPress: EmptyFn;
+  onPress?: EmptyFn;
 }
 
 export const TokenListItem: FC<Props> = ({ token, apy, onPress }) => {
   const styles = useTokenListItemStyles();
   const dispatch = useDispatch();
+  const { navigate } = useNavigation();
 
   useEffect(() => {
     const slug = getTokenSlug(token);
     if (slug !== TEZ_TOKEN_SLUG) {
-      dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
+      dispatch(loadTokenBalanceActions.submit(getTokenSlug(token)));
     }
   }, [dispatch]);
 
+  const handleOnPress = useCallback(() => {
+    if (onPress) {
+      onPress();
+
+      return;
+    }
+    navigate(ScreensEnum.TokenScreen, { token });
+  }, [onPress]);
+
   return (
-    <TouchableOpacity onPress={onPress}>
+    <TouchableOpacity onPress={handleOnPress}>
       <TokenContainer token={token} apy={apy}>
         <View style={styles.rightContainer}>
           <HideBalance style={styles.balanceText}>

--- a/src/screens/wallet/token-list/token-list-item/token-list-item.tsx
+++ b/src/screens/wallet/token-list/token-list-item/token-list-item.tsx
@@ -1,5 +1,5 @@
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect } from 'react';
 import { View } from 'react-native';
 import { useDispatch } from 'react-redux';
 
@@ -9,6 +9,7 @@ import { TokenContainer } from '../../../../components/token-container/token-con
 import { TokenContainerProps } from '../../../../components/token-container/token-container.props';
 import { EmptyFn } from '../../../../config/general';
 import { loadRenderTokenBalanceActions } from '../../../../store/wallet/wallet-actions';
+import { TEZ_TOKEN_SLUG } from '../../../../token/data/tokens-metadata';
 import { getTokenSlug } from '../../../../token/utils/token.utils';
 import { useTokenListItemStyles } from './token-list-item.styles';
 
@@ -20,9 +21,12 @@ export const TokenListItem: FC<Props> = ({ token, apy, onPress }) => {
   const styles = useTokenListItemStyles();
   const dispatch = useDispatch();
 
-  useMemo(() => {
-    dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
-  }, []);
+  useEffect(() => {
+    const slug = getTokenSlug(token);
+    if (slug !== TEZ_TOKEN_SLUG) {
+      dispatch(loadRenderTokenBalanceActions.submit(getTokenSlug(token)));
+    }
+  }, [dispatch]);
 
   return (
     <TouchableOpacity onPress={onPress}>

--- a/src/screens/wallet/token-list/token-list.tsx
+++ b/src/screens/wallet/token-list/token-list.tsx
@@ -33,6 +33,8 @@ const keyExtractor = (item: FlatListItem) => {
   return getTokenSlug(item);
 };
 
+const limit = 10;
+
 const renderFlatListItem: ListRenderItem<FlatListItem> = ({ item }) => {
   if (item === TEZ_TOKEN_SLUG) {
     return <TezosToken />;
@@ -48,7 +50,7 @@ export const TokenList: FC = () => {
   const tezosToken = useSelectedAccountTezosTokenSelector();
   const visibleTokensList = useVisibleTokensListSelector();
   const isHideZeroBalanceMemo = useHideZeroBalances();
-  const [itemsCount, setItemsCount] = useState<number>(10);
+  const [itemsCount, setItemsCount] = useState(limit);
   const handleHideZeroBalanceChange = useCallback((value: boolean) => {
     dispatch(setZeroBalancesShown(value));
   }, []);
@@ -96,7 +98,7 @@ export const TokenList: FC = () => {
           keyExtractor={keyExtractor}
           ListEmptyComponent={<DataPlaceholder text="No records found." />}
           onEndReachedThreshold={0.5}
-          onEndReached={() => setItemsCount(itemsCount + 10)}
+          onEndReached={() => setItemsCount(itemsCount + limit)}
         />
       </View>
     </>

--- a/src/store/wallet/wallet-actions.ts
+++ b/src/store/wallet/wallet-actions.ts
@@ -15,10 +15,10 @@ export const setAccountVisibility = createAction<{ publicKeyHash: string; isVisi
 );
 
 // TODO: extract AssetsState
-export const loadTokenBalancesActions = createActions<void, Record<string, string>, string>('assets/LOAD_TOKENS');
+export const loadTokensWithBalancesActions = createActions<void, Record<string, string>, string>('assets/LOAD_TOKENS');
 export const loadTezosBalanceActions = createActions<void, string, string>('assets/LOAD_TEZOS');
 
-export const loadRenderTokenBalanceActions = createActions<string, { slug: string; balance: string }, string>(
+export const loadTokenBalanceActions = createActions<string, { slug: string; balance: string }, string>(
   'assets/LOAD_RENDER_TOKENS_BALANCE'
 );
 

--- a/src/store/wallet/wallet-actions.ts
+++ b/src/store/wallet/wallet-actions.ts
@@ -18,6 +18,10 @@ export const setAccountVisibility = createAction<{ publicKeyHash: string; isVisi
 export const loadTokenBalancesActions = createActions<void, Record<string, string>, string>('assets/LOAD_TOKENS');
 export const loadTezosBalanceActions = createActions<void, string, string>('assets/LOAD_TEZOS');
 
+export const loadRenderTokenBalanceActions = createActions<string, { slug: string; balance: string }, string>(
+  'assets/LOAD_RENDER_TOKENS_BALANCE'
+);
+
 export const addTokenAction = createAction<TokenMetadataInterface>('assets/ADD_TOKEN');
 export const removeTokenAction = createAction<string>('assets/REMOVE_TOKEN');
 export const toggleTokenVisibilityAction = createAction<string>('assets/TOGGLE_TOKEN_VISIBILITY');

--- a/src/store/wallet/wallet-reducers.ts
+++ b/src/store/wallet/wallet-reducers.ts
@@ -11,7 +11,8 @@ import {
   setSelectedAccountAction,
   toggleTokenVisibilityAction,
   updateAccountAction,
-  setAccountVisibility
+  setAccountVisibility,
+  loadRenderTokenBalanceActions
 } from './wallet-actions';
 import { walletInitialState, WalletState } from './wallet-state';
 import {
@@ -72,6 +73,12 @@ export const walletReducers = createReducer<WalletState>(walletInitialState, bui
       tokensList: pushOrUpdateTokensBalances(currentAccount.tokensList, balancesRecord)
     }))
   );
+
+  builder.addCase(loadRenderTokenBalanceActions.success, (state, { payload: { slug, balance } }) => {
+    return updateCurrentAccountState(state, currentAccount => ({
+      tokensList: pushOrUpdateTokensBalances(currentAccount.tokensList, { [slug]: balance })
+    }));
+  });
 
   builder.addCase(addTokenAction, (state, { payload: tokenMetadata }) => {
     const slug = getTokenSlug(tokenMetadata);

--- a/src/store/wallet/wallet-reducers.ts
+++ b/src/store/wallet/wallet-reducers.ts
@@ -6,13 +6,13 @@ import {
   addHdAccountAction,
   addTokenAction,
   loadTezosBalanceActions,
-  loadTokenBalancesActions,
+  loadTokensWithBalancesActions,
   removeTokenAction,
   setSelectedAccountAction,
   toggleTokenVisibilityAction,
   updateAccountAction,
   setAccountVisibility,
-  loadRenderTokenBalanceActions
+  loadTokenBalanceActions
 } from './wallet-actions';
 import { walletInitialState, WalletState } from './wallet-state';
 import {
@@ -69,13 +69,13 @@ export const walletReducers = createReducer<WalletState>(walletInitialState, bui
     updateCurrentAccountState(state, () => ({ tezosBalance }))
   );
 
-  builder.addCase(loadTokenBalancesActions.success, (state, { payload: balancesRecord }) =>
+  builder.addCase(loadTokensWithBalancesActions.success, (state, { payload: balancesRecord }) =>
     updateCurrentAccountState(state, currentAccount => ({
       tokensList: pushNewTokenBalances(currentAccount.tokensList, balancesRecord)
     }))
   );
 
-  builder.addCase(loadRenderTokenBalanceActions.success, (state, { payload: { slug, balance } }) => {
+  builder.addCase(loadTokenBalanceActions.success, (state, { payload: { slug, balance } }) => {
     return updateCurrentAccountState(state, currentAccount => ({
       tokensList: pushOrUpdateTokensBalances(currentAccount.tokensList, { [slug]: balance })
     }));

--- a/src/store/wallet/wallet-reducers.ts
+++ b/src/store/wallet/wallet-reducers.ts
@@ -16,6 +16,7 @@ import {
 } from './wallet-actions';
 import { walletInitialState, WalletState } from './wallet-state';
 import {
+  pushNewTokenBalances,
   pushOrUpdateTokensBalances,
   toggleTokenVisibility,
   updateAccountState,
@@ -70,7 +71,7 @@ export const walletReducers = createReducer<WalletState>(walletInitialState, bui
 
   builder.addCase(loadTokenBalancesActions.success, (state, { payload: balancesRecord }) =>
     updateCurrentAccountState(state, currentAccount => ({
-      tokensList: pushOrUpdateTokensBalances(currentAccount.tokensList, balancesRecord)
+      tokensList: pushNewTokenBalances(currentAccount.tokensList, balancesRecord)
     }))
   );
 

--- a/src/store/wallet/wallet-state.utils.ts
+++ b/src/store/wallet/wallet-state.utils.ts
@@ -36,6 +36,25 @@ export const updateAccountState = (
   };
 };
 
+export const pushNewTokenBalances = (initialTokensList: AccountTokenInterface[], balances: Record<string, string>) => {
+  const localBalances: Record<string, string> = { ...balances };
+  const result: AccountTokenInterface[] = [];
+
+  for (const token of initialTokensList) {
+    const balance = localBalances[token.slug];
+    if (isDefined(balance)) {
+      delete localBalances[token.slug];
+    }
+    result.push(token);
+  }
+
+  result.push(
+    ...Object.entries(localBalances).map(([slug, balance]) => ({ slug, balance, visibility: VisibilityEnum.Visible }))
+  );
+
+  return result;
+};
+
 export const pushOrUpdateTokensBalances = (
   initialTokensList: AccountTokenInterface[],
   balances: Record<string, string>

--- a/src/utils/token-balance.utils.ts
+++ b/src/utils/token-balance.utils.ts
@@ -1,6 +1,5 @@
-import { TezosToolkit } from '@taquito/taquito';
 import { BigNumber } from 'bignumber.js';
-import { forkJoin, from, of } from 'rxjs';
+import { from, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 
 import { tzktApi } from '../api.service';
@@ -30,8 +29,26 @@ export const loadTezosBalance$ = (rpcUrl: string, publicKeyHash: string) =>
     map(balance => balance.toFixed())
   );
 
-const loadAssetBalance$ = (tezos: TezosToolkit, publicKeyHash: string, assetSlug: string) => {
+type cachedAssetBalance = {
+  time: number;
+  value?: string;
+};
+
+const cachedResults: Record<string, cachedAssetBalance> = {
+  // KT1234654645: 123
+};
+
+const CACHE_TIME = 1000 * 60; // 1 minute
+
+export const loadAssetBalance$ = (rpcUrl: string, publicKeyHash: string, assetSlug: string) => {
+  const tezos = createReadOnlyTezosToolkit(rpcUrl, readOnlySignerAccount);
   const [assetAddress, assetId = '0'] = assetSlug.split('_');
+
+  const cachedRecord = cachedResults[`${publicKeyHash}_${assetSlug}`];
+
+  if (isDefined(cachedRecord) && Date.now() - cachedRecord.time < CACHE_TIME && isDefined(cachedRecord.value)) {
+    return of(cachedRecord.value);
+  }
 
   return from(tezos.contract.at(assetAddress)).pipe(
     switchMap(contract => {
@@ -43,28 +60,36 @@ const loadAssetBalance$ = (tezos: TezosToolkit, publicKeyHash: string, assetSlug
         return contract.views.getBalance(publicKeyHash).read();
       }
     }),
-    map((balance: BigNumber) => (balance.isNaN() ? undefined : balance.toFixed())),
+    map((balance: BigNumber) => {
+      const returnValue = balance.isNaN() ? undefined : balance.toFixed();
+      cachedResults[`${publicKeyHash}_${assetSlug}`] = {
+        time: Date.now(),
+        value: returnValue
+      };
+
+      return returnValue;
+    }),
     catchError(() => of(undefined))
   );
 };
 
-export const loadAssetsBalances$ = (rpcUrl: string, publicKeyHash: string, assetSlugs: string[]) =>
-  forkJoin(
-    assetSlugs.map(assetSlug =>
-      loadAssetBalance$(createReadOnlyTezosToolkit(rpcUrl, readOnlySignerAccount), publicKeyHash, assetSlug)
-    )
-  ).pipe(
-    map((balancesList: (string | undefined)[]) => {
-      const balancesRecord: Record<string, string> = {};
+// export const loadAssetsBalances$ = (rpcUrl: string, publicKeyHash: string, assetSlugs: string[]) =>
+//   forkJoin(
+//     assetSlugs.map(assetSlug =>
+//       loadAssetBalance$(createReadOnlyTezosToolkit(rpcUrl, readOnlySignerAccount), publicKeyHash, assetSlug)
+//     )
+//   ).pipe(
+//     map((balancesList: (string | undefined)[]) => {
+//       const balancesRecord: Record<string, string> = {};
 
-      for (let index = 0; index < assetSlugs.length; index++) {
-        const balance = balancesList[index];
+//       for (let index = 0; index < assetSlugs.length; index++) {
+//         const balance = balancesList[index];
 
-        if (isDefined(balance)) {
-          balancesRecord[assetSlugs[index]] = balance;
-        }
-      }
+//         if (isDefined(balance)) {
+//           balancesRecord[assetSlugs[index]] = balance;
+//         }
+//       }
 
-      return balancesRecord;
-    })
-  );
+//       return balancesRecord;
+//     })
+//   );

--- a/src/utils/token-balance.utils.ts
+++ b/src/utils/token-balance.utils.ts
@@ -35,7 +35,7 @@ type cachedAssetBalance = {
 };
 
 const cachedResults: Record<string, cachedAssetBalance> = {
-  // KT1234654645: 123
+  // tz123456_KT1234654645: {time: <timestamp>, value: <balance>}
 };
 
 const CACHE_TIME = 1000 * 60; // 1 minute
@@ -69,27 +69,8 @@ export const loadAssetBalance$ = (rpcUrl: string, publicKeyHash: string, assetSl
 
       return returnValue;
     }),
-    catchError(() => of(undefined))
+    catchError(() => {
+      return of(undefined);
+    })
   );
 };
-
-// export const loadAssetsBalances$ = (rpcUrl: string, publicKeyHash: string, assetSlugs: string[]) =>
-//   forkJoin(
-//     assetSlugs.map(assetSlug =>
-//       loadAssetBalance$(createReadOnlyTezosToolkit(rpcUrl, readOnlySignerAccount), publicKeyHash, assetSlug)
-//     )
-//   ).pipe(
-//     map((balancesList: (string | undefined)[]) => {
-//       const balancesRecord: Record<string, string> = {};
-
-//       for (let index = 0; index < assetSlugs.length; index++) {
-//         const balance = balancesList[index];
-
-//         if (isDefined(balance)) {
-//           balancesRecord[assetSlugs[index]] = balance;
-//         }
-//       }
-
-//       return balancesRecord;
-//     })
-//   );

--- a/src/utils/token-metadata.utils.ts
+++ b/src/utils/token-metadata.utils.ts
@@ -1,8 +1,9 @@
 import memoize from 'mem';
 import { from, Observable } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { map, filter, withLatestFrom } from 'rxjs/operators';
 
 import { tokenMetadataApi } from '../api.service';
+import { TokensMetadataRootState, TokensMetadataState } from '../store/tokens-metadata/tokens-metadata-state';
 import { TokenMetadataInterface } from '../token/interfaces/token-metadata.interface';
 import { getTokenSlug } from '../token/utils/token.utils';
 import { isDefined } from './is-defined';
@@ -14,6 +15,16 @@ export interface TokenMetadataResponse {
   thumbnailUri?: string;
   artifactUri?: string;
 }
+
+export const withMetadataSlugs =
+  <T>(state$: Observable<TokensMetadataRootState>) =>
+  (observable$: Observable<T>) =>
+    observable$.pipe(
+      withLatestFrom(state$, (value, { tokensMetadata }): [T, Record<string, TokenMetadataInterface>] => [
+        value,
+        tokensMetadata.metadataRecord
+      ])
+    );
 
 const transformDataToTokenMetadata = (token: TokenMetadataResponse | null, address: string, id: number) =>
   !isDefined(token)

--- a/src/utils/token-metadata.utils.ts
+++ b/src/utils/token-metadata.utils.ts
@@ -3,7 +3,7 @@ import { from, Observable } from 'rxjs';
 import { map, filter, withLatestFrom } from 'rxjs/operators';
 
 import { tokenMetadataApi } from '../api.service';
-import { TokensMetadataRootState, TokensMetadataState } from '../store/tokens-metadata/tokens-metadata-state';
+import { TokensMetadataRootState } from '../store/tokens-metadata/tokens-metadata-state';
 import { TokenMetadataInterface } from '../token/interfaces/token-metadata.interface';
 import { getTokenSlug } from '../token/utils/token.utils';
 import { isDefined } from './is-defined';


### PR DESCRIPTION
- Added pagination on wallet's token list, load more on scroll to the end
- Move load balances from 60 seconds interval's epic to onRender side of TokenItem component
- Refactored `onPress` (navigation) prop in TokenListItem, to prevent re-renders of flatlisted `TokenList`